### PR TITLE
try/catch rulecosi

### DIFF
--- a/src/RuleCosiplus/src/main.jl
+++ b/src/RuleCosiplus/src/main.jl
@@ -29,8 +29,26 @@ PyCall.Conda.pip("install", "git+https://github.com/jobregon1212/rulecosi.git", 
 PyCall.Conda.pip("install", "scikit-learn", PyCall.Conda.ROOTENV)
 
 function __init__()
-    copy!(rulecosi, pyimport_conda("rulecosi", "rulecosi"))
-    copy!(sklearn, pyimport_conda("sklearn.ensemble", "sklearn"))
+    # First ensure pip interop is enabled
+    Conda.pip_interop(true, PyCall.Conda.ROOTENV)
+    
+    # Try to import rulecosi, if it fails, install it via pip
+    try
+        copy!(rulecosi, pyimport("rulecosi"))
+    catch
+        @info "Installing rulecosi via pip..."
+        PyCall.Conda.pip("install", "git+https://github.com/jobregon1212/rulecosi.git", PyCall.Conda.ROOTENV)
+        copy!(rulecosi, pyimport("rulecosi"))
+    end
+    
+    # Try to import sklearn, if it fails, install it via pip  
+    try
+        copy!(sklearn, pyimport("sklearn.ensemble"))
+    catch
+        @info "Installing scikit-learn via pip..."
+        PyCall.Conda.pip("install", "scikit-learn", PyCall.Conda.ROOTENV)
+        copy!(sklearn, pyimport("sklearn.ensemble"))
+    end
 
     py"""
     import numpy as np


### PR DESCRIPTION
While locally every test work like a charm, remote testing usiong GitHub CI always reported errors.
It happens also in another package I was working on, and this is my proposal fix.
It seems that `__init__` function not always works on GitHub CI, sometimes yes, sometimes not.
My proposal is to add a try/catch to force the download of `rulecosi` via `Conda.pip`.
I tested SoleXplorer to see if it's working and, if you take a look at SoleXplorer's Actions, it works!