### PR TITLE
Fix bellatrex on non-ensemble models (fixes #95)

### DIFF
--- a/src/bellatrex.jl
+++ b/src/bellatrex.jl
@@ -25,19 +25,15 @@ function bellatrex(
     rng::AbstractRNG = MersenneTwister(1),
     kwargs...,
 )
+    isensemble(m) || error("`bellatrex` requires an ensemble model.")
+
     ########################################################################################
     # Extract rules from each tree, obtain full ruleset
     ########################################################################################
     ftrees = trees(m)
     ndatasetinstances = ninstances(X)
     final_predictions = []
-    ruleset = begin
-        if isensemble(m)
-            unique([listrules(tree; use_shortforms = true) for tree in ftrees])
-        else
-            listrules(model)
-        end
-    end
+    ruleset = unique([listrules(tree; use_shortforms = true) for tree in ftrees])
 
     # 1) For each instance in X, we would extract the most adaptive rules for it
     for idx = 1:ndatasetinstances

--- a/src/rule-extraction.jl
+++ b/src/rule-extraction.jl
@@ -175,4 +175,17 @@ function extractrules(::RULECOSIPLUSRuleExtractor, m, args...; kwargs...)
     return dsrulecosiplus
 end
 
+#===========================================================================================
+                                        BELLATREX
+===========================================================================================#
+export bellatrex, BellatrexRuleExtractor
+include("bellatrex.jl")
+
+"""$(_get_rule_extractor_docstring("BellatrexRuleExtractor", bellatrex))"""
+struct BellatrexRuleExtractor <: RuleExtractor end
+
+function extractrules(::BellatrexRuleExtractor, m, args...; kwargs...)
+    return bellatrex(m, args...; kwargs...)
+end
+
 end

--- a/test/bellatrex.jl
+++ b/test/bellatrex.jl
@@ -1,23 +1,35 @@
-pwd()
-Pkg.activate()
-Pkg.add("PyCall")
-
-using PyCall
-@pyimport bellatrex
+using Test
+using SoleModels
+using SoleData
 using SolePostHoc
+using DataFrames
 
+@testset "BELLATREX" begin
+    # 1. Non-ensemble model (single DecisionTree)
+    t1 = SoleModels.DecisionTree(LeafModel("classA"))
+    t2 = SoleModels.DecisionTree(LeafModel("classB"))
+    df = DataFrame(feature1 = [1.0, 2.0], feature2 = [3.0, 4.0])
+    X = scalarlogiset(df, allow_propositional=true)
+    Y = ["classA", "classB"]
 
-const req_py_pkgs = ["bellatrex"]
-const fs = PyNULL()
+    @test !isensemble(t1)
 
-function __init__()
-    pypkgs = getindex.(PyCall.Conda.parseconda(`list`, PyCall.Conda.ROOTENV), "name")
-    needinstall = !all(p -> in(p, pypkgs), req_py_pkgs)
-
-    if (needinstall)
-        PyCall.Conda.pip_interop(true, PyCall.Conda.ROOTENV)
-        PyCall.Conda.add(req_py_pkgs)
+    # Regression test for Issue #95: bellatrex on a non-ensemble model must refuse with a clear error
+    # (previously raised UndefVarError: model not defined or MethodError on trees(m) before isensemble guard)
+    @test_throws ErrorException bellatrex(t1, X, Y)
+    try
+        bellatrex(t1, X, Y)
+    catch err
+        @test err isa ErrorException
+        @test contains(err.msg, "bellatrex")
+        @test contains(err.msg, "ensemble")
     end
 
-    copy!(fs, pyimport_conda("bellatrex.BellatrexExplain", "bellatrex"))
+    # Also test via extractrules interface with BellatrexRuleExtractor
+    @test_throws ErrorException extractrules(BellatrexRuleExtractor(), t1, X, Y)
+
+    # 2. Ensemble model (DecisionForest)
+    forest = SoleModels.DecisionForest([t1, t2])
+    @test isensemble(forest)
+    @test trees(forest) == [t1, t2]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,8 @@ println("Julia version: ", VERSION)
 test_suites = [
     ("Generic rule Extraction test with rule_extraction.jl", ["rule_extraction.jl"]),
     ("InTrees", ["intrees.jl"]),
-    ("ORCA Forest Compression", ["orca_compression.jl"])
+    ("ORCA Forest Compression", ["orca_compression.jl"]),
+    ("BELLATREX", ["bellatrex.jl"])
 ]
 
 @testset "SolePostHoc.jl" begin


### PR DESCRIPTION
Fixes #95.

### Reachability Note
On `main`, `src/bellatrex.jl` is not included by `SolePostHoc.jl` or `rule-extraction.jl`, and `test/bellatrex.jl` was not listed in `test/runtests.jl`. The defects fixed here are real issues in the source code of `src/bellatrex.jl`, but are currently unreachable through the published package interface.

Making the fix testable within the package test suite requires including `src/bellatrex.jl` and registering the extractor in `src/rule-extraction.jl`. To keep product decisions under maintainer control, this PR is structured into two independent commits:

### Commit Structure

1. **Commit 1 (`1bb79bd`): `Fix bellatrex on non-ensemble models (fixes #95)`** — **Standalone Bug Fix**
   - Placed `isensemble(m) || error(...)` at the top of `bellatrex` in `src/bellatrex.jl`, before `trees(m)` is called. This ensures non-ensemble models produce an immediate, clear refusal error rather than triggering a `MethodError` on `trees(m)`.
   - Replaced the broken `else` block (`listrules(model)`) with direct rule extraction from `trees(m)`, resolving the `UndefVarError` on unbound `model`.
   - Modifies *only* `src/bellatrex.jl`.

2. **Commit 2 (`58daa1b`): `Activate BELLATREX module and register BellatrexRuleExtractor`** — **Optional Module Activation**
   - Includes `bellatrex.jl` in `src/rule-extraction.jl` and exports `bellatrex` and `BellatrexRuleExtractor` (with trailing newline restored).
   - Replaces the draft `test/bellatrex.jl` with unit and regression tests for issue #95 and adds `BELLATREX` to `test/runtests.jl`.
   - Maintainers can drop this commit if `bellatrex` activation/registration should remain pending.
